### PR TITLE
aumenta TTL do JWT para 30 dias e trata sessao expirada no AuthContext

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -9,7 +9,15 @@ export function AuthProvider({ children }) {
         // localStorage persiste entre abas e recarregamentos
         try {
             const salvo = localStorage.getItem("auth");
-            return salvo ? JSON.parse(salvo) : null;
+            if (!salvo) return null;
+            const parsed = JSON.parse(salvo);
+            // Sessão expirada: trata como deslogado em vez de manter estado autenticado
+            // até o primeiro 401 do backend.
+            if (parsed?.expiraEm && parsed.expiraEm <= Date.now()) {
+                localStorage.removeItem("auth");
+                return null;
+            }
+            return parsed;
         } catch {
             return null;
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,7 +38,7 @@ spring.flyway.validate-on-migrate=false
 
 # -- JWT ----------------------------------------------------------------------
 jwt.secret=${JWT_SECRET:whallet-dev-secret-local-apenas-nao-usar-em-producao-512bits}
-jwt.expiration-ms=${JWT_EXPIRATION_MS:28800000}
+jwt.expiration-ms=${JWT_EXPIRATION_MS:2592000000}
 
 # -- Spring Security ----------------------------------------------------------
 # Desativa o formulario de login padrao do Spring Security


### PR DESCRIPTION
Sobe expiracao padrao de 8h para 30d (sobrescritivel via JWT_EXPIRATION_MS) e faz o AuthProvider limpar localStorage na inicializacao quando expiraEm ja passou, evitando estado "logado" enganoso ate o primeiro 401.